### PR TITLE
add more security to pulumi recipe 

### DIFF
--- a/pulumi/Pulumi.yaml
+++ b/pulumi/Pulumi.yaml
@@ -21,20 +21,14 @@ config:
   ami:
     type: string
     description: A valid AMI used to deploy on AD jumphost (must be Ubuntu 20.04 LTS)
-    default: ami-07b36ea9852e986ad 
-  Domain:
+    default: ami-0d86ecafd19013f31 
+#    default: ami-07b36ea9852e986ad 
+
+  domain_name:
     type: string
     description: Name of Domain to be used for AD 
     default: pwb.posit.co
-  DomainPW:
-    type: string
-    description: Password for the Administrator AD account 
-    default: Testme123! 
   db_username:
     type: string
     description: Username for the PostgreSQL db
     default: pwb_db_admin 
-  db_password:
-    type: string
-    description: Password for the PostgreSQL db
-    default: pwb_db_password 

--- a/pulumi/README.md
+++ b/pulumi/README.md
@@ -4,5 +4,6 @@
 just key-pair-new
 pulumi stack init benchmark
 pulumi config set email my-email@posit.co
+just create-secrets
 just up 
 ```

--- a/pulumi/justfile
+++ b/pulumi/justfile
@@ -1,3 +1,5 @@
+set shell := ["bash"]
+
 key-pair-new:
     just key-pair-new-script
     chmod 400 key.pem
@@ -10,12 +12,22 @@ key-pair-new-script:
    echo "" | ssh-keygen -t rsa -f key.pem
 
 create-users num="10":
+    #!/bin/bash
     ssh \
-        -i key.pem \
+        -i "$(pulumi stack output 'key_pair id').pem" \
         -o StrictHostKeyChecking=no \
         ubuntu@$(pulumi stack output ad_jump_host_public_ip) \
         "bash useradd.sh {{num}}"
 
+create-secrets:
+    #!/bin/bash
+    pulumi config set domain_password --secret `python -c "import random,string; x=''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=12));print(x)"`
+    pulumi config set user_password --secret `python -c "import random,string; x=''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=12));print(x)"`
+    pulumi config set db_password --secret `python -c "import random,string; x=''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=12));print(x)"`
+    export email=`pulumi config get email`
+    export keyname="${email}-keypair-for-pulumi"
+    aws ec2 describe-key-pairs --key-names=$keyname
+    if [ $? -ne 0 ]; then aws ec2 create-key-pair --key-name $keyname --query 'KeyMaterial' --output text > ${keyname}.pem ; fi
 
 up: 
     pulumi up -y

--- a/pulumi/server-side-files/config/useradd.sh
+++ b/pulumi/server-side-files/config/useradd.sh
@@ -8,8 +8,8 @@ do
         while true
             do
                 username=posit\`printf %04i \$i\`
-	            expect create-users.exp \$username Testme1234
-                echo "Testme1234" | pamtester login posit0001 authenticate
+	            expect create-users.exp \$username {{user_password}} 
+                echo {{user_password}} | pamtester login \$username authenticate
                 if [ \$? -eq 0 ]; then
                     break 
                 fi


### PR DESCRIPTION
This PR adresses: 

- Remove any hard-coded password from the pulumi recipe (DB, Active Directory, Default User)
- Creating any passwords via `python -c "import random,string; x=''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=12));print(x)"` to create a 12-character string with random upper+lowercase letters + digits (12^(2*26+10) possibilities). 
- Storing all passwords in pulumi in encrypted form `pulumi config set user_password --secret ...`
- Creating passwords and secrets via `just create-secrets`
- Renaming of various variable names to make things more consistent
- Minor general improvements
